### PR TITLE
fix: properly use timeout flag so that it can be adjusted for port scans

### DIFF
--- a/src/whos_home.py
+++ b/src/whos_home.py
@@ -31,6 +31,7 @@ def now(
     only_arp: Annotated[bool, t.Option(help="Run scans with just an ARP packet")] = False,
     icmp_and_arp: Annotated[bool, t.Option(help="Run scans with just an ICMP and ARP packet")] = True,
     verbose: Annotated[bool, t.Option(help="Verbose output when invoking nmap scans")] = False,
+    timeout: Annotated[int, t.Option(help="Control the duration of the command execution")] = 60,
 ) -> None:
     """
     Discover hosts on the network using nmap
@@ -39,7 +40,7 @@ def now(
     if verbose:
         Logger().enable()
 
-    executor: NmapExecutor = NmapExecutor(host=host, cidr=cidr)
+    executor: NmapExecutor = NmapExecutor(host=host, cidr=cidr, timeout=timeout)
     result_from_scan: CommandResult = execute_scan_based_on_flag(only_arp, only_icmp, icmp_and_arp, executor)
 
     if result_from_scan.success:


### PR DESCRIPTION
## Description

Properly use timeout flag and pass through to nmap executor, marking issue as resolved for now as we still may want to manually change the timeout when running the port scan, flag is still a needed addition 

#24 

## Changes in this pull request

- Add timeout flag 

[//]: # (List changes in this pull request )
