### PR TITLE
chore: properly handle timeout errors and pass the timeout to the executor only once

### DIFF
--- a/src/executor/default_executor.py
+++ b/src/executor/default_executor.py
@@ -25,6 +25,7 @@ class DefaultExecutor:
         """
         self.timeout = timeout
         self.warn_about_sudo = warn_about_sudo
+        self.timeout_warning = False
 
     def execute(self, command: str) -> CommandResult:
         """
@@ -52,6 +53,17 @@ class DefaultExecutor:
                 .apply_bold_red(f" error occurred whilst executing nmap command, error: {e} ")
                 .build()
             )
+        except (TimeoutError, subprocess.TimeoutExpired):
+            if not self.timeout_warning:
+                rich.print(
+                    TyperOutputBuilder()
+                    .add_exclamation_mark()
+                    .apply_bold_red(
+                        f" Timeout occurred whilst executing command! Consider raising the timeout value with --timeout flag. "
+                    )
+                    .build()
+                )
+                self.timeout_warning = True
 
         Logger().debug("Creating command result.... ")
         return CommandResult.create_command_result(result, command)

--- a/src/output/nmap_output.py
+++ b/src/output/nmap_output.py
@@ -116,7 +116,7 @@ def build_os_info_message(device_from_port_scan: Device) -> str:
         .apply_bold_red(
             message=f"{device_from_port_scan.os.name} | "
             f"{device_from_port_scan.os.vendor} | "
-            f"{device_from_port_scan.os.family} | "
+            f"{device_from_port_scan.os.family} "
         )
         .build()
     )

--- a/src/whos_home.py
+++ b/src/whos_home.py
@@ -40,7 +40,7 @@ def main(
     """
     Discover hosts on the network using nmap
     """
-    executor: NmapExecutor = NmapExecutor(host=host, cidr=cidr)
+    executor: NmapExecutor = NmapExecutor(host=host, cidr=cidr, timeout=timeout)
     result_from_host_discovery: CommandResult = execute_host_discovery_based_on_flag(
         only_arp, only_icmp, icmp_and_arp, executor
     )
@@ -48,7 +48,6 @@ def main(
     if verbose:
         Logger().enable()
 
-    executor: NmapExecutor = NmapExecutor(host=host, cidr=cidr, timeout=timeout)
     if check:
         results_from_check: CommandResult = executor.execute_version_command()
         format_and_output_from_check(command_result=results_from_check)
@@ -70,7 +69,6 @@ def main(
                 ),
             )
 
-        # if enhanced_port_scan and port_scan:
         if extended_port_scan:
             Logger().debug("Beginning port scan....")
             ips: list[str] = [device.ip_addr for device in outputted_devices]


### PR DESCRIPTION
## Description

Properly handle timeout exceptions and warn the user if the timeout was reached

[//]: # (Describe the changes in this pull request)

## Changes in this pull request

- Add message to handle the timeout exceptions 
- Define the executor properly and pass the timeout through 

[//]: # (List changes in this pull request )
