### PR TITLE
Feat: Ability to scan multiple ranges, full port scan and vendor information addded to mac address.

### DIFF
--- a/src/data/scan_result.py
+++ b/src/data/scan_result.py
@@ -125,7 +125,11 @@ class ScanResult:
 
         for address in addresses:
             if address["@addrtype"] == address_type:
-                return address["@addr"]
+                if address_type == "mac":
+                    if address.get("@vendor") and address["@vendor"].strip():
+                        return f"{address['@addr']} | {address['@vendor']}"
+                    return f"{address['@addr']} | (Unknown Vendor)"
+                return f"{address['@addr']}"
         return None
 
     def find_hostname(self, i: int) -> Any | None:

--- a/src/executor/nmap_executor.py
+++ b/src/executor/nmap_executor.py
@@ -182,3 +182,28 @@ class NmapExecutor:
         )
 
         return self.executor.async_pooled_execute(commands, events)
+
+    def execute_full_port_scan(self, ips: list[str], events: ExecutorCallbackEvents) -> list[CommandResult]:
+        """
+        Executes a full port scan on a list of provided IP addresses.
+        :param ips:
+        :param events:
+        :return:
+        """
+        Logger().debug(f"Executing general port scan on {ips}")
+
+        commands: list[str] = list(
+            map(
+                lambda ip: NmapCommandBuilder(ip, self.cidr)
+                .enable_service_scan()
+                .enable_full_port_scan()
+                .enable_aggressive_timing()
+                .enable_skip_host_discovery()
+                .enable_os_detection()
+                .enable_xml_to_stdout()
+                .build_without_cidr(),
+                ips,
+            )
+        )
+
+        return self.executor.async_pooled_execute(commands, events)

--- a/src/util/nmap_command_builder.py
+++ b/src/util/nmap_command_builder.py
@@ -66,6 +66,9 @@ class NmapCommandBuilder:
     def enable_exclude_ports(self) -> NmapCommandBuilder:
         return self.enable_flag(AvailableNmapFlags.EXCLUDE_PORTS)
 
+    def enable_full_port_scan(self) -> NmapCommandBuilder:
+        return self.enable_flag(AvailableNmapFlags.FULL_PORT_SCAN)
+
     def enable_aggressive_timing(self) -> NmapCommandBuilder:
         return self.enable_flag(AvailableNmapFlags.AGGRESSIVE_TIMING)
 

--- a/tests/output/test_nmap_output.py
+++ b/tests/output/test_nmap_output.py
@@ -45,19 +45,19 @@ def test_build_ip_message():
 
 def test_build_mac_addr_message_with_mac():
     device = NmapDevice(ip_addr="x", mac_addr="AA:BB:CC", hostname="host", os=None, ports=None)
-    msg = build_mac_addr_message(device)
+    msg = build_mac_addr_message(device, int(len(device.mac_addr)))
     assert "AA:BB:CC" in msg
 
 
 def test_build_mac_addr_message_without_mac():
     device = NmapDevice(ip_addr="x", mac_addr=None, hostname="host", os=None, ports=None)
-    msg = build_mac_addr_message(device)
+    msg = build_mac_addr_message(device, 0)
     assert msg is None
 
 
 def test_get_ip_and_mac_message_with_mac():
     device = NmapDevice(ip_addr="1.2.3.4", mac_addr="00:00:00", hostname="abc", os=None, ports=None)
-    msg = get_ip_and_mac_message(device)
+    msg = get_ip_and_mac_message(device, [device])
     assert "1.2.3.4" in msg
     assert "00:00:00" in msg
     assert "abc" in msg
@@ -65,7 +65,7 @@ def test_get_ip_and_mac_message_with_mac():
 
 def test_get_ip_and_mac_message_without_mac():
     device = NmapDevice(ip_addr="1.2.3.4", mac_addr=None, hostname="abc", os=None, ports=None)
-    msg = get_ip_and_mac_message(device)
+    msg = get_ip_and_mac_message(device, [device])
     assert "1.2.3.4" in msg
     assert "abc" in msg
     assert "mac" not in msg.lower()


### PR DESCRIPTION
### Features:
- The `host` var in args can now include multiple ips/ranges with something like `whos-home.py "192.168.1.0 192.168.5.0" {other args}`. This will perform host discovery and port scanning on `192.168.1.0/24` and when that is finished, will do the same with `192.168.5.0/24`.
- Added `--full-port-scan` flag, which performs a full port scan on the hosts found using the `-p-` nmap flag.
- Added vendor information (e.g. `Samsung Technologies` or `Apple`), to the MAC address information in the host discovery output.

### Note:
The vendor information might need reformatting in the future.
